### PR TITLE
Fix duplicate import in agent deploy script

### DIFF
--- a/workshop-code/03-langGraph-create-register-deploy-tool-calling-agent.py
+++ b/workshop-code/03-langGraph-create-register-deploy-tool-calling-agent.py
@@ -236,7 +236,6 @@ from mlflow.models.resources import (
     DatabricksGenieSpace,
     DatabricksServingEndpoint,
     DatabricksVectorSearchIndex,
-    DatabricksFunction
 )
 
 # TODO: Manually include underlying resources if needed. See the TODO in the markdown above for more information.


### PR DESCRIPTION
## Summary
- remove duplicate DatabricksFunction import

## Testing
- `python -m py_compile workshop-code/03-langGraph-create-register-deploy-tool-calling-agent.py`
- `python -m py_compile workshop-code/05-build-databricks-agents-app/model_serving_utils.py`
- `python -m py_compile workshop-code/05-build-databricks-agents-app/app.py`
